### PR TITLE
Fix rendering issue and update Camera

### DIFF
--- a/src/io/github/twhscs/game/AnimatedSprite.java
+++ b/src/io/github/twhscs/game/AnimatedSprite.java
@@ -174,4 +174,12 @@ public class AnimatedSprite {
     IntRect textureCoordsRect = new IntRect(topX, topY, spriteSize.x, spriteSize.y);
     return textureCoordsRect;
   }
+  
+  /**
+   * Get the size of the sprite as a vector.
+   * @return An integer vector containing the sprite size.
+   */
+  public Vector2i getSpriteSize() {
+    return spriteSize;
+  }
 }

--- a/src/io/github/twhscs/game/Camera.java
+++ b/src/io/github/twhscs/game/Camera.java
@@ -3,6 +3,7 @@ package io.github.twhscs.game;
 import org.jsfml.graphics.RenderWindow;
 import org.jsfml.graphics.View;
 import org.jsfml.system.Vector2f;
+import org.jsfml.system.Vector2i;
 
 /**
  * Camera that can center on various objects.
@@ -29,17 +30,23 @@ public class Camera {
   }
   
   /**
-   * Center the camera on the following position.
-   * @param pos The position to center the camera on.
-   * @param step Kyle ?
+   * Center the camera on the position of an animated sprite.
+   * @param s The sprite to center on.
    */
-  public void centerOn(Vector2f pos, float step) {
-    /* View newView = 
-     * new View(vectorLerp(defaultView.getCenter(), pos, step), defaultView.getSize());
-     */
-    View newView = new View(defaultView.getCenter(), defaultView.getSize());
-    newView.setCenter(pos);
-    window.setView(newView);
+  public void centerOn(AnimatedSprite s) {
+    // Copy the default view
+    View newView = new View(defaultView.getCenter(), defaultView.getSize()); 
+    Vector2f spritePos = s.getSprite().getPosition(); // Get the vector position of the sprite
+    Vector2i spriteSize = s.getSpriteSize(); // Get the size of the sprite
+    // Convert the size to a float
+    Vector2f newSpriteSize = new Vector2f(spriteSize.x, spriteSize.y); 
+    newSpriteSize = Vector2f.div(newSpriteSize, 2); // Divide the size in half (for centering)
+    // Combine half the sprite size with the position
+    Vector2f cameraPos = Vector2f.add(spritePos, newSpriteSize); 
+    // Round the final position to prevent graphical artifacts
+    cameraPos = new Vector2f(Math.round(cameraPos.x), Math.round(cameraPos.y));
+    newView.setCenter(cameraPos); // Set the new position
+    window.setView(newView); // Set the view
   }
   
   /**
@@ -47,27 +54,5 @@ public class Camera {
    */
   public void centerOnDefault() {
     window.setView(defaultView);
-  }
-  
-  /**
-   * Kyle ?
-   * @param x0
-   * @param x1
-   * @param m
-   * @return
-   */
-  public float lerp(float x0, float x1, float m) {
-    return x0 + m * (x1 - x0);
-  }
-  
-  /**
-   * Kyle ?
-   * @param v0
-   * @param v1
-   * @param m
-   * @return
-   */
-  public Vector2f vectorLerp(Vector2f v0, Vector2f v1, float m) {
-    return new Vector2f(lerp(v0.x, v1.x, m), lerp(v0.y, v1.y, m));
   }
 }

--- a/src/io/github/twhscs/game/Game.java
+++ b/src/io/github/twhscs/game/Game.java
@@ -4,7 +4,6 @@ import org.jsfml.graphics.Color;
 import org.jsfml.graphics.RenderWindow;
 import org.jsfml.graphics.TextStyle;
 import org.jsfml.system.Clock;
-import org.jsfml.system.Vector2f;
 import org.jsfml.system.Vector2i;
 import org.jsfml.window.Keyboard;
 import org.jsfml.window.Keyboard.Key;
@@ -158,11 +157,10 @@ public class Game {
     // The window has automatic double buffering
     window.clear(); // Wipe everything from the window
     // Draw each object like layers, background to foreground
-    Vector2f playerPos = player.getSprite().getPosition();
-    camera.centerOn(playerPos, 0);
+    camera.centerOn(player.getAnimatedSprite()); // Draw everything relative to player, centering it
     window.draw(player.getMap()); 
     window.draw(player);
-    camera.centerOnDefault();
+    camera.centerOnDefault(); // Stop drawing relative to the player
     window.draw(fpsUI);
     window.display(); // Show the window to the user
   }

--- a/src/io/github/twhscs/game/Player.java
+++ b/src/io/github/twhscs/game/Player.java
@@ -131,8 +131,8 @@ public class Player extends Entity implements Drawable {
    * Get animated sprite.
    * @return Animated sprite.
    */
-  public Sprite getSprite() {
-    return playerSprite.getSprite();
+  public AnimatedSprite getAnimatedSprite() {
+    return playerSprite;
   }
   
   /**


### PR DESCRIPTION
I was able to fix the rendering bug in #21 and while I was at it I cleaned up some of the camera class. @Bassics originally implemented interpolation in the camera class but because I implemented the same thing for animated sprites we were essentially doing the same thing twice. I now have the camera centering on the player, which has interpolation.
